### PR TITLE
Patch for 1.16

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -196,7 +196,7 @@ Flash:
     - "Flash radius: 32"
   recipe:
     - GLOWSTONE_DUST TNT GLOWSTONE_DUST
-    - TNT EYE_OF_ENDER TNT
+    - TNT ENDER_EYE TNT
     - GLOWSTONE_DUST TNT GLOWSTONE_DUST
   amount: 4
   scenario:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: CustomNukes
 main: com.gmail.uprial.customnukes.CustomNukes
+api-version: 1.16
 version: 0.2.11
 commands:
    customnukes:


### PR DESCRIPTION
The current version of the plugin doesn't allow materials like the `NETHERITE_INGOT` and `WITHER_SKELETON_SKULL` to be used in the custom recipes. This pull request should fix that problem by forcing the API version to 1.16.